### PR TITLE
fix: redis security group rules

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "redis_allow_ingress_from_sg" {
   source_security_group_id = var.sg_allow_ingress_to_redis
   description              = "Allow TCP/6379 (Redis) inbound to Redis cluster from specified security group ID."
 
-  security_group_id = aws_security_group.rds_allow_ingress.id
+  security_group_id = aws_security_group.redis_allow_ingress.id
 }
 
 resource "aws_security_group_rule" "redis_allow_ingress_from_cidr" {
@@ -89,5 +89,5 @@ resource "aws_security_group_rule" "redis_allow_ingress_from_cidr" {
   cidr_blocks = var.cidr_allow_ingress_to_redis
   description = "Allow TCP/6379 (Redis) inbound to Redis cluster from specified CIDR ranges."
 
-  security_group_id = aws_security_group.rds_allow_ingress.id
+  security_group_id = aws_security_group.redis_allow_ingress.id
 }


### PR DESCRIPTION
## Description
Redis security group rules were incorrectly referencing the RDS security group ID

## Related issue
Issue raised by customer through Solutions Architecture contact

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Visual check that the changed rules now match `redis_allow_ingress_from_nodegroup` which is correct
- No further testing completed 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
I don't have the environment ready to run a test of this, so would appreciate someone else doing this if they think it is necessary.
