### PR TITLE
Update metrics sg rule count to check for value by length function.

### DIFF
--- a/eks_nodegroup.tf
+++ b/eks_nodegroup.tf
@@ -161,7 +161,7 @@ resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_https_from_lb" {
 }
 
 resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_http_from_cidr" {
-  count = var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_http) > 0 ? 1 : 0
+  count = var.cidr_allow_ingress_tfe_metrics_http != null ? ( var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_http) > 0 ? 1 : 0) : 0
 
   type        = "ingress"
   from_port   = var.tfe_metrics_http_port
@@ -174,7 +174,7 @@ resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_http_fro
 }
 
 resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_https_from_cidr" {
-  count = var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_http) > 0 ? 1 : 0
+  count = var.cidr_allow_ingress_tfe_metrics_https != null ? ( var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_https) > 0 ? 1 : 0) : 0
 
   type        = "ingress"
   from_port   = var.tfe_metrics_https_port

--- a/eks_nodegroup.tf
+++ b/eks_nodegroup.tf
@@ -161,7 +161,7 @@ resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_https_from_lb" {
 }
 
 resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_http_from_cidr" {
-  count = var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 ? 1 : 0
+  count = var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_http) > 0 ? 1 : 0
 
   type        = "ingress"
   from_port   = var.tfe_metrics_http_port
@@ -174,7 +174,7 @@ resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_http_fro
 }
 
 resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_https_from_cidr" {
-  count = var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 ? 1 : 0
+  count = var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_http) > 0 ? 1 : 0
 
   type        = "ingress"
   from_port   = var.tfe_metrics_https_port

--- a/examples/existing-eks-cluster/terraform.tfvars.example
+++ b/examples/existing-eks-cluster/terraform.tfvars.example
@@ -12,11 +12,13 @@ tfe_fqdn                   = "<tfe.aws.example.com>"
 create_helm_overrides_file = true
 
 # --- Networking --- #
-vpc_id                     = "<my-vpc-id>"
-eks_subnet_ids             = ["<my-eks-subnet-id-a>", "<my-eks-subnet-id-b>", "<my-eks-subnet-id-c>"]
-rds_subnet_ids             = ["<my-rds-subnet-id-a>", "<my-rds-subnet-id-b>", "<my-rds-subnet-id-c>"]
-redis_subnet_ids           = ["<my-redis-subnet-id-a>", "<my-redis-subnet-id-b>", "<my-redis-subnet-id-c>"]
-cidr_allow_ingress_tfe_443 = ["0.0.0.0/0"] # CIDR ranges of your TFE users/clients and VCS
+vpc_id                                = "<my-vpc-id>"
+eks_subnet_ids                        = ["<my-eks-subnet-id-a>", "<my-eks-subnet-id-b>", "<my-eks-subnet-id-c>"]
+rds_subnet_ids                        = ["<my-rds-subnet-id-a>", "<my-rds-subnet-id-b>", "<my-rds-subnet-id-c>"]
+redis_subnet_ids                      = ["<my-redis-subnet-id-a>", "<my-redis-subnet-id-b>", "<my-redis-subnet-id-c>"]
+cidr_allow_ingress_tfe_443            = ["0.0.0.0/0"] # CIDR ranges of your TFE users/clients and VCS
+cidr_allow_ingress_tfe_metrics_http   = ["0.0.0.0/0"] 
+cidr_allow_ingress_tfe_metrics_https  = ["0.0.0.0/0"]
 
 # --- Database --- #
 tfe_database_password_secret_arn = "<my-database-password-secret-arn>"

--- a/examples/existing-eks-cluster/variables.tf
+++ b/examples/existing-eks-cluster/variables.tf
@@ -118,12 +118,22 @@ variable "cidr_allow_ingress_tfe_metrics_http" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/9090 (TFE HTTP metrics endpoint) inbound to TFE pods."
   default     = []
+
+  validation {
+    condition = var.cidr_allow_ingress_tfe_metrics_http != null ? length(var.cidr_allow_ingress_tfe_metrics_http) > 0 : true
+    error_message = "If not null, must contain at least one CIDR range."
+  }
 }
 
 variable "cidr_allow_ingress_tfe_metrics_https" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/9091 (TFE HTTPS metrics endpoint) inbound to TFE pods."
   default     = []
+
+  validation {
+    condition = var.cidr_allow_ingress_tfe_metrics_https != null ? length(var.cidr_allow_ingress_tfe_metrics_https) > 0 : true
+    error_message = "If not null, must contain at least one CIDR range."
+  }
 }
 
 variable "cidr_allow_egress_from_tfe_lb" {

--- a/examples/new-eks-cluster/terraform.tfvars.example
+++ b/examples/new-eks-cluster/terraform.tfvars.example
@@ -12,11 +12,13 @@ tfe_fqdn                   = "<tfe.aws.example.com>"
 create_helm_overrides_file = true
 
 # --- Networking --- #
-vpc_id                     = "<my-vpc-id>"
-eks_subnet_ids             = ["<my-eks-subnet-id-a>", "<my-eks-subnet-id-b>", "<my-eks-subnet-id-c>"]
-rds_subnet_ids             = ["<my-rds-subnet-id-a>", "<my-rds-subnet-id-b>", "<my-rds-subnet-id-c>"]
-redis_subnet_ids           = ["<my-redis-subnet-id-a>", "<my-redis-subnet-id-b>", "<my-redis-subnet-id-c>"]
-cidr_allow_ingress_tfe_443 = ["0.0.0.0/0"] # CIDR ranges of your TFE users/clients and VCS
+vpc_id                                = "<my-vpc-id>"
+eks_subnet_ids                        = ["<my-eks-subnet-id-a>", "<my-eks-subnet-id-b>", "<my-eks-subnet-id-c>"]
+rds_subnet_ids                        = ["<my-rds-subnet-id-a>", "<my-rds-subnet-id-b>", "<my-rds-subnet-id-c>"]
+redis_subnet_ids                      = ["<my-redis-subnet-id-a>", "<my-redis-subnet-id-b>", "<my-redis-subnet-id-c>"]
+cidr_allow_ingress_tfe_443            = ["0.0.0.0/0"] # CIDR ranges of your TFE users/clients and VCS
+cidr_allow_ingress_tfe_metrics_http   = ["0.0.0.0/0"] 
+cidr_allow_ingress_tfe_metrics_https  = ["0.0.0.0/0"]
 
 # --- IAM --- #
 create_eks_oidc_provider      = true

--- a/examples/new-eks-cluster/variables.tf
+++ b/examples/new-eks-cluster/variables.tf
@@ -118,12 +118,22 @@ variable "cidr_allow_ingress_tfe_metrics_http" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/9090 (TFE HTTP metrics endpoint) inbound to TFE pods."
   default     = []
+
+  validation {
+    condition = var.cidr_allow_ingress_tfe_metrics_http != null ? length(var.cidr_allow_ingress_tfe_metrics_http) > 0 : true
+    error_message = "If not null, must contain at least one CIDR range."
+  }
 }
 
 variable "cidr_allow_ingress_tfe_metrics_https" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/9091 (TFE HTTPS metrics endpoint) inbound to TFE pods."
   default     = []
+
+  validation {
+    condition = var.cidr_allow_ingress_tfe_metrics_https != null ? length(var.cidr_allow_ingress_tfe_metrics_https) > 0 : true
+    error_message = "If not null, must contain at least one CIDR range."
+  }
 }
 
 variable "cidr_allow_egress_from_tfe_lb" {

--- a/variables.tf
+++ b/variables.tf
@@ -105,12 +105,22 @@ variable "cidr_allow_ingress_tfe_metrics_http" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/9090 (TFE HTTP metrics endpoint) inbound to TFE pods."
   default     = []
+
+  validation {
+    condition = var.cidr_allow_ingress_tfe_metrics_http != null ? length(var.cidr_allow_ingress_tfe_metrics_http) > 0 : true
+    error_message = "If not null, must contain at least one CIDR range. ."
+  }
 }
 
 variable "cidr_allow_ingress_tfe_metrics_https" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/9091 (TFE HTTPS metrics endpoint) inbound to TFE pods."
   default     = []
+
+  validation {
+    condition = var.cidr_allow_ingress_tfe_metrics_https != null ? length(var.cidr_allow_ingress_tfe_metrics_https) > 0 : true
+    error_message = "If not null, must contain at least one CIDR range."
+  }
 }
 
 variable "cidr_allow_egress_from_tfe_lb" {


### PR DESCRIPTION
## Description
Something I bumped into when running deploying a new solution using the new eks cluster example. 

If both : 

**cidr_allow_ingress_tfe_metrics_http**  
**cidr_allow_ingress_tfe_metrics_https**

Have empty `[]`, the security group rule would attempt to apply, but fail after 10 minutes. 

Add a bit to check that there are values in both cidr_allow_ingress_tfe_metrics_http & cidr_allow_ingress_tfe_metrics_http. 

Variable validation on both: 

```hcl
variable "cidr_allow_ingress_tfe_metrics_http" {
  type        = list(string)
  description = "List of CIDR ranges to allow TCP/9090 (TFE HTTP metrics endpoint) inbound to TFE pods."
  default     = []

  validation {
    condition = var.cidr_allow_ingress_tfe_metrics_http != null ? length(var.cidr_allow_ingress_tfe_metrics_http) > 0 : true
    error_message = "If not null, must contain at least one CIDR range."
  }
}

variable "cidr_allow_ingress_tfe_metrics_https" {
  type        = list(string)
  description = "List of CIDR ranges to allow TCP/9091 (TFE HTTPS metrics endpoint) inbound to TFE pods."
  default     = []

  validation {
    condition = var.cidr_allow_ingress_tfe_metrics_https != null ? length(var.cidr_allow_ingress_tfe_metrics_https) > 0 : true
    error_message = "If not null, must contain at least one CIDR range."
  }
}
```

Maybe a bit overkill, but resources also check it in the count, while also allowing `null` to be used. 

```hcl
resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_http_from_cidr" {
  count = var.cidr_allow_ingress_tfe_metrics_http != null ? ( var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_http) > 0 ? 1 : 0) : 0

  type        = "ingress"
  from_port   = var.tfe_metrics_http_port
  to_port     = var.tfe_metrics_http_port
  protocol    = "tcp"
  cidr_blocks = var.cidr_allow_ingress_tfe_metrics_http
  description = "Allow TCP/9090 (TFE HTTP metrics endpoint) inbound to node group from specified CIDR ranges."

  security_group_id = aws_security_group.tfe_eks_nodegroup_allow[0].id
}

resource "aws_security_group_rule" "tfe_eks_nodegroup_allow_tfe_metrics_https_from_cidr" {
  count = var.cidr_allow_ingress_tfe_metrics_https != null ? ( var.create_eks_cluster && length(aws_security_group.tfe_lb_allow) > 0 && length(var.cidr_allow_ingress_tfe_metrics_https) > 0 ? 1 : 0) : 0

  type        = "ingress"
  from_port   = var.tfe_metrics_https_port
  to_port     = var.tfe_metrics_https_port
  protocol    = "tcp"
  cidr_blocks = var.cidr_allow_ingress_tfe_metrics_https
  description = "Allow TCP/9091 (TFE HTTPS metrics endpoint) inbound to node group from specified CIDR ranges."

  security_group_id = aws_security_group.tfe_eks_nodegroup_allow[0].id
}
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
1. When running both with null: 

cidr_allow_ingress_tfe_metrics_http  = null
cidr_allow_ingress_tfe_metrics_https = null

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Security group exists, but no metric rules added. 

![image](https://github.com/user-attachments/assets/82f9851e-a767-44e3-80a6-de93713df3a2)

2. Running with empty `[]` lists. 

cidr_allow_ingress_tfe_metrics_http  = []
cidr_allow_ingress_tfe_metrics_https = []

```
│ Error: Invalid value for variable
│ 
│   on main.tf line 34, in module "tfe":
│   34:   cidr_allow_ingress_tfe_metrics_http  = var.cidr_allow_ingress_tfe_metrics_http
│     ├────────────────
│     │ var.cidr_allow_ingress_tfe_metrics_http is empty list of string
│ 
│ If not null, must contain at least one CIDR range.
│ 
│ This was checked by the validation rule at ../../modules/terraform-aws-terraform-enterprise-eks-hvd/variables.tf:109,3-13.
╵
╷
│ Error: Invalid value for variable
│ 
│   on main.tf line 35, in module "tfe":
│   35:   cidr_allow_ingress_tfe_metrics_https = var.cidr_allow_ingress_tfe_metrics_https
│     ├────────────────
│     │ var.cidr_allow_ingress_tfe_metrics_https is empty list of string
│ 
│ If not null, must contain at least one CIDR range.
│ 
│ This was checked by the validation rule at ../../modules/terraform-aws-terraform-enterprise-eks-hvd/variables.tf:120,3-13.
```

Variable validation picks up that there is an empty list. 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

