### PR TITLE
Destroy bucket ability

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "tfe" {
     var.common_tags
   )
 
-  force_destroy = true
+  force_destroy = var.force_destroy_s3_bucket
 }
 
 resource "aws_s3_bucket_public_access_block" "tfe" {

--- a/s3.tf
+++ b/s3.tf
@@ -11,6 +11,8 @@ resource "aws_s3_bucket" "tfe" {
     { "Name" = "${var.friendly_name_prefix}-tfe-app-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}" },
     var.common_tags
   )
+
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "tfe" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "common_tags" {
   default     = {}
 }
 
+variable "force_destroy_s3_bucket" {
+  type = bool
+  description = "ability to detroy the s3 bucket if needed"
+  default = false
+}
+
 variable "is_secondary_region" {
   type        = bool
   description = "Boolean indicating whether this TFE deployment is in the 'primary' region or 'secondary' region."


### PR DESCRIPTION
## Description
when you use the module to create test environments when doing a detroy it wil fail because of objects in the bucket. This is great to protect customers but would be nice to have the ability to override the settings

created a variable with a default false as it was but now you can alter it

## Related issue
[Link to the related issue (if applicable)]

## Type of change
- [z ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
personal test

## Checklist
- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
