### PR TITLE
Add serviceAccount name to Helm overrides template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
   - Private key must **not** be password protected
 - TLS certificate authority (CA) bundle (_e.g._ `ca_bundle.pem`) corresponding with the CA that issues your TFE TLS certificates
   - CA bundle must be in PEM format
+  - You may include additional certificate chains corresponding to external systems that TFE will make outbound connections to (_e.g._ your self-hosted VCS, if its certificate was issued by a different CA than your TFE certificate).
 
->📝 Note: The TLS certificate and private key will be created as Kubernetes secrets durint the [Post Steps](#post-steps).
+>📝 Note: The TLS certificate and private key will be created as Kubernetes secrets during the [Post Steps](#post-steps).
 
 ### Secrets management
 

--- a/locals_helm_overrides.tf
+++ b/locals_helm_overrides.tf
@@ -3,8 +3,9 @@
 
 locals {
   helm_overrides_values = {
-    # IAM role for TFE Kubernetes service account (IRSA)
-    tfe_eks_irsa_arn = var.create_tfe_eks_irsa ? aws_iam_role.tfe_irsa[0].arn : ""
+    # Service account
+    tfe_eks_irsa_arn     = var.create_tfe_eks_irsa ? aws_iam_role.tfe_irsa[0].arn : ""
+    tfe_kube_svc_account = var.tfe_kube_svc_account
 
     # Service annotations
     tfe_lb_security_groups = var.create_eks_cluster ? aws_security_group.tfe_lb_allow[0].id : ""

--- a/templates/helm_overrides_values.yaml.tpl
+++ b/templates/helm_overrides_values.yaml.tpl
@@ -7,11 +7,13 @@ tls:
 image:
  repository: images.releases.hashicorp.com
  name: hashicorp/terraform-enterprise
- tag: <v202407-1>
+ tag: <v202503-1> # refer to https://developer.hashicorp.com/terraform/enterprise/releases
 
 %{ if tfe_eks_irsa_arn != "" ~}
 serviceAccount:
-  annotations: 
+  enabled: true
+  name: ${tfe_kube_svc_account}
+  annotations:
     eks.amazonaws.com/role-arn: ${tfe_eks_irsa_arn}
 %{ endif ~}
 
@@ -27,7 +29,7 @@ service:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
-    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal" # for an external LB, set to "internet-facing"
     service.beta.kubernetes.io/aws-load-balancer-subnets: "<list, of, lb_subnet_ids>" # TFE load balancer subnets, no brackets in annotation list
     service.beta.kubernetes.io/aws-load-balancer-security-groups: ${tfe_lb_security_groups}
   type: LoadBalancer


### PR DESCRIPTION
## Description
Within the `serviceAccount` block, explicitly setting `enable: true` (even though this is the chart default) and being explicit with how the service account name is set (rather than relying on taking the name of the TFE namespace) within the Helm overrides template that the module generates.

Also added a few helper comments to the template, and fixed a typo on the main README.

## Related issue
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
Successful Terraform apply and Helm install.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
