### PR TITLE
feat: add OIDC provider outputs for IRSA configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="output_elasticache_replication_group_arn"></a> [elasticache\_replication\_group\_arn](#output\_elasticache\_replication\_group\_arn) | ARN of ElastiCache Replication Group (Redis) cluster. |
 | <a name="output_elasticache_replication_group_id"></a> [elasticache\_replication\_group\_id](#output\_elasticache\_replication\_group\_id) | ID of ElastiCache Replication Group (Redis) cluster. |
 | <a name="output_elasticache_replication_group_primary_endpoint_address"></a> [elasticache\_replication\_group\_primary\_endpoint\_address](#output\_elasticache\_replication\_group\_primary\_endpoint\_address) | Primary endpoint address of ElastiCache Replication Group (Redis) cluster. |
+| <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | URL of the OIDC provider for the EKS cluster. Required for configuring IRSA (IAM Roles for Service Accounts). |
+| <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | ARN of the OIDC provider for the EKS cluster. Required for configuring IRSA (IAM Roles for Service Accounts). |
 | <a name="output_rds_aurora_cluster_arn"></a> [rds\_aurora\_cluster\_arn](#output\_rds\_aurora\_cluster\_arn) | ARN of RDS Aurora database cluster. |
 | <a name="output_rds_aurora_cluster_endpoint"></a> [rds\_aurora\_cluster\_endpoint](#output\_rds\_aurora\_cluster\_endpoint) | RDS Aurora database cluster endpoint. |
 | <a name="output_rds_aurora_cluster_members"></a> [rds\_aurora\_cluster\_members](#output\_rds\_aurora\_cluster\_members) | List of instances that are part of this RDS Aurora database cluster. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,6 +50,16 @@ output "eks_cluster_endpoint" {
   description = "Endpoint URL for the TFE EKS cluster (from `aws_eks_cluster.tfe[0].endpoint`). Useful for building a custom EKS node group `user_data` template."
 }
 
+output "oidc_provider_arn" {
+  value       = try(aws_iam_openid_connect_provider.tfe_eks_irsa[0].arn, null)
+  description = "ARN of the OIDC provider for the EKS cluster. Required for configuring IRSA (IAM Roles for Service Accounts)."
+}
+
+output "oidc_provider" {
+  value       = try(aws_iam_openid_connect_provider.tfe_eks_irsa[0].url, null)
+  description = "URL of the OIDC provider for the EKS cluster. Required for configuring IRSA (IAM Roles for Service Accounts)."
+}
+
 #------------------------------------------------------------------------------
 # Database
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR adds two new outputs to support IAM Roles for Service Accounts (IRSA) configuration in EKS:

- `oidc_provider_arn` - ARN of the OIDC provider for the EKS cluster
- `oidc_provider` - URL of the OIDC provider for the EKS cluster

## Motivation

These outputs are required when setting up IRSA, which allows Kubernetes service accounts to assume IAM roles using OIDC authentication. The engineering team identified these as missing outputs needed for their IRSA setup.

## Changes

- Added `oidc_provider_arn` output that references `aws_iam_openid_connect_provider.tfe_eks_irsa[0].arn`
- Added `oidc_provider` output that references `aws_iam_openid_connect_provider.tfe_eks_irsa[0].url`
- Both outputs use `try()` to handle cases where the OIDC provider is not created

## Testing

- ✅ `task test` passes (terraform fmt, init, validate)
- ✅ All examples validate successfully

Closes #58